### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,47 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: Test (PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Laravel 11
+          - php: '8.2'
+            laravel: '11.*'
+            testbench: '^9.0'
+            pest-plugin-laravel: '^3.1'
+          - php: '8.3'
+            laravel: '11.*'
+            testbench: '^9.0'
+            pest-plugin-laravel: '^3.1'
+          - php: '8.4'
+            laravel: '11.*'
+            testbench: '^9.0'
+            pest-plugin-laravel: '^3.1'
+          # Laravel 12
+          - php: '8.2'
+            laravel: '12.*'
+            testbench: '^10.2'
+            pest-plugin-laravel: '^3.1'
+          - php: '8.3'
+            laravel: '12.*'
+            testbench: '^10.2'
+            pest-plugin-laravel: '^3.1'
+          - php: '8.4'
+            laravel: '12.*'
+            testbench: '^10.2'
+            pest-plugin-laravel: '^3.1'
+          # Laravel 13 (PHP 8.3+ only — enforced by Laravel itself)
+          - php: '8.3'
+            laravel: '13.*'
+            testbench: '^11.0'
+            pest-plugin-laravel: '^4.0'
+          - php: '8.4'
+            laravel: '13.*'
+            testbench: '^11.0'
+            pest-plugin-laravel: '^4.0'
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +95,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -67,11 +107,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-php${{ matrix.php }}-laravel${{ matrix.laravel }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-php${{ matrix.php }}-laravel${{ matrix.laravel }}-
+            ${{ runner.os }}-composer-
 
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+      - name: Install dependencies (Laravel ${{ matrix.laravel }})
+        run: |
+          composer require \
+            "laravel/framework:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            "pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}" \
+            --no-interaction --no-update --dev
+          composer update --no-interaction --prefer-dist --with-all-dependencies
 
       - name: Run Unit tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Digital Shopfront CMS Accessibility Changelog
 
+## [Unreleased]
+
+### Added
+- Added Laravel 13 support. The `illuminate/support` framework constraint now resolves against `^11.0|^12.0|^13.0`. Existing users on Laravel 11 or 12 are unaffected, and Laravel 13 is only selectable on PHP 8.3+ via Laravel's own constraint — no PHP-floor bump is required.
+- Added a CI matrix that runs the test suite against Laravel 11, 12, and 13 on every supported PHP version (8.2 for L11/12, 8.3+ for L13).
+
+### Changed
+- Promoted `illuminate/support` from `suggest` to a hard `require` so the multi-version framework constraint is enforced at install time. The Laravel integration layer (service provider, facade, HTTP/API controllers) has always required `illuminate/support` at runtime.
+- Widened dev dependency constraints to cover the Laravel 13 toolchain: `orchestra/testbench` to `^9.0|^10.2|^11.0`, `pestphp/pest` to `^3.8|^4.0`, and `pestphp/pest-plugin-laravel` to `^3.1|^4.0`. The lock file still resolves to the Laravel 12 toolchain for local development; the CI matrix overrides per-row to exercise the other framework versions.
+- Updated supported-versions notes in `README.md` and `docs/guides/getting-started.md` to reflect Laravel 11/12/13.
+- Removed Laravel 5.x manual-registration instructions from `docs/guides/getting-started.md` (auto-discovery is automatic on every supported Laravel version) and corrected the documented service-provider and facade class names to match the actual namespaces.
+
 ## [2.1.1] - 2026-01-09
 
 This release integrates the package with the core ArtisanPack UI package for a unified configuration structure.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ For complete documentation, please visit the links below.
 ## Requirements
 
 - PHP 8.2 or higher
-- Laravel 5.3 or higher (for Laravel integration)
+- Laravel 11, 12, or 13 (for Laravel integration)
+
+> Laravel 13 requires PHP 8.3 or higher. Users staying on Laravel 11 or 12 may continue to use PHP 8.2.
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -37,15 +37,13 @@
   ],
   "require": {
     "php": "^8.2",
-    "artisanpack-ui/core": "^1.0"
-  },
-  "suggest": {
-    "illuminate/support": "Required for Laravel integration."
+    "artisanpack-ui/core": "^1.0",
+    "illuminate/support": "^11.0|^12.0|^13.0"
   },
   "require-dev": {
-    "pestphp/pest": "^3.8",
-    "pestphp/pest-plugin-laravel": "^3.1",
-    "orchestra/testbench": "^10.2",
+    "pestphp/pest": "^3.8|^4.0",
+    "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+    "orchestra/testbench": "^9.0|^10.2|^11.0",
     "squizlabs/php_codesniffer": "^3.13",
     "artisanpack-ui/code-style": "^1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,19 +4,19 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "383c6035d5048a679ec6eeacfb390c2f",
+    "content-hash": "74a1d2f2df717e26d609f742618f5b72",
     "packages": [
         {
             "name": "artisanpack-ui/core",
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-core.git",
+                "url": "https://github.com/ArtisanPack-UI/core.git",
                 "reference": "b84b5772c562ffd9deda2fdb443cceabfe1f0d84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/jacob-martella-web-design%2Fartisanpack-ui%2Fartisanpack-ui-core/repository/archive.zip?sha=b84b5772c562ffd9deda2fdb443cceabfe1f0d84",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/b84b5772c562ffd9deda2fdb443cceabfe1f0d84",
                 "reference": "b84b5772c562ffd9deda2fdb443cceabfe1f0d84",
                 "shasum": ""
             },
@@ -5832,12 +5832,12 @@
             "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-code-style.git",
+                "url": "https://github.com/ArtisanPack-UI/code-style.git",
                 "reference": "0846b13a2932467e6ef7e4877deabe859b25b113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/jacob-martella-web-design%2Fartisanpack-ui%2Fartisanpack-ui-code-style/repository/archive.zip?sha=0846b13a2932467e6ef7e4877deabe859b25b113",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style/zipball/0846b13a2932467e6ef7e4877deabe859b25b113",
                 "reference": "0846b13a2932467e6ef7e4877deabe859b25b113",
                 "shasum": ""
             },
@@ -5880,12 +5880,12 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-code-style-pint.git",
+                "url": "https://github.com/ArtisanPack-UI/code-style-pint.git",
                 "reference": "198a9e02ea022c17c2a80692cf4423ecf28b43ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/jacob-martella-web-design%2Fartisanpack-ui%2Fartisanpack-ui-code-style-pint/repository/archive.zip?sha=198a9e02ea022c17c2a80692cf4423ecf28b43ee",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/code-style-pint/zipball/198a9e02ea022c17c2a80692cf4423ecf28b43ee",
                 "reference": "198a9e02ea022c17c2a80692cf4423ecf28b43ee",
                 "shasum": ""
             },

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,7 +9,9 @@ This guide will help you get started with the ArtisanPack UI Accessibility packa
 ## Requirements
 
 - PHP 8.2 or higher
-- Laravel 5.3 or higher (for Laravel integration)
+- Laravel 11, 12, or 13 (for Laravel integration)
+
+> Laravel 13 requires PHP 8.3 or higher. Users staying on Laravel 11 or 12 may continue to use PHP 8.2.
 
 ## Installation
 
@@ -21,27 +23,21 @@ composer require artisanpack-ui/accessibility
 
 ## Laravel Integration
 
-### Service Provider Registration
+The `A11yServiceProvider` and the `A11y` facade alias are registered automatically via Laravel's package auto-discovery — no manual registration required.
 
-If you're using Laravel 5.5 or higher with package auto-discovery, the service provider will be automatically registered.
-
-For Laravel 5.3 or 5.4, you need to manually add the service provider to your `config/app.php` file:
+If you have disabled auto-discovery for this package (for example by listing it in your application's `extra.laravel.dont-discover` array), register them manually:
 
 ```php
-'providers' => [
-    // Other service providers...
-    ArtisanPackUI\Accessibility\A11yServiceProvider::class,
-],
-```
+// bootstrap/providers.php
+return [
+    // ...
+    ArtisanPack\Accessibility\Laravel\A11yServiceProvider::class,
+];
 
-### Facade Registration
-
-If you want to use the A11y facade, you can add it to the aliases array in your `config/app.php` file:
-
-```php
+// config/app.php (only if you use the A11y facade alias)
 'aliases' => [
-    // Other aliases...
-    'A11y' => ArtisanPackUI\Accessibility\Facades\A11y::class,
+    // ...
+    'A11y' => ArtisanPack\Accessibility\Laravel\Facades\A11y::class,
 ],
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -25,7 +25,7 @@ composer require artisanpack-ui/accessibility
 
 The `A11yServiceProvider` and the `A11y` facade alias are registered automatically via Laravel's package auto-discovery — no manual registration required.
 
-If you have disabled auto-discovery for this package (for example by listing it in your application's `extra.laravel.dont-discover` array), register them manually:
+If you have disabled auto-discovery for this package (for example by listing it in your application's `extra.laravel.dont-discover` array), register the service provider in `bootstrap/providers.php`:
 
 ```php
 // bootstrap/providers.php
@@ -33,12 +33,18 @@ return [
     // ...
     ArtisanPack\Accessibility\Laravel\A11yServiceProvider::class,
 ];
+```
 
-// config/app.php (only if you use the A11y facade alias)
-'aliases' => [
-    // ...
-    'A11y' => ArtisanPack\Accessibility\Laravel\Facades\A11y::class,
-],
+If you also want to use the short `A11y` facade alias, register it via the `AliasLoader` from the `register()` method of one of your application service providers (Laravel 11+ no longer ships an `aliases` array in `config/app.php`):
+
+```php
+use ArtisanPack\Accessibility\Laravel\Facades\A11y;
+use Illuminate\Foundation\AliasLoader;
+
+public function register(): void
+{
+    AliasLoader::getInstance()->alias('A11y', A11y::class);
+}
 ```
 
 ## Basic Usage


### PR DESCRIPTION
## Description

Widens the package's framework support to include Laravel 13 alongside Laravel 11 and 12. This is a purely additive change: no currently-supported framework version is dropped and the PHP floor is unchanged at `^8.2` — Laravel 13 is only selectable on PHP 8.3+ via Laravel's own platform constraint.

While here, the PR also bundles the related toolchain and documentation work flagged on the original issue ticket so the v2.1.2 release surface is clean.

**Closes:** #29

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #29

## Motivation and Context

Laravel 13 was released and requires PHP 8.3+. We want users on Laravel 13 to be able to install `artisanpack-ui/accessibility` without dropping support for users staying on Laravel 11 or 12, and without forcing a PHP-floor bump.

The original issue scoped the change narrowly to the `composer.json` constraint and docs. After discussion in the implementation thread, the three items the issue listed as "track separately" (CI matrix, testbench bump, legacy doc cleanup) were rolled into this PR for a cleaner v2.1.2 release boundary.

## Changes Made

- **`composer.json`** — promoted `illuminate/support` from `suggest` to `require` with `^11.0|^12.0|^13.0`. The Laravel integration layer (service provider, facade, HTTP/API controllers) has always required `illuminate/support` at runtime, so this brings the manifest in line with reality.
- **`composer.json`** — widened dev dependency constraints to cover the Laravel 13 toolchain: `orchestra/testbench` → `^9.0|^10.2|^11.0`, `pestphp/pest` → `^3.8|^4.0`, `pestphp/pest-plugin-laravel` → `^3.1|^4.0`. Local lock still resolves to the L12 toolchain.
- **`.github/workflows/ci.yml`** — added a CI matrix across Laravel 11/12/13 × PHP 8.2/8.3/8.4 (L13 rows restricted to PHP 8.3+, per Laravel's platform constraint). Each row pins per-row `composer require` overrides for framework, testbench, and pest-plugin-laravel.
- **`README.md` + `docs/guides/getting-started.md`** — refreshed Requirements sections to list Laravel 11/12/13 with a PHP 8.3+ note for L13.
- **`docs/guides/getting-started.md`** — removed the obsolete "Laravel 5.5 auto-discovery / Laravel 5.3 or 5.4 manual registration" guidance (every supported framework version auto-discovers) and corrected the service-provider / facade namespaces to match `composer.json`'s `extra.laravel.providers` and `extra.laravel.aliases` entries.
- **`CHANGELOG.md`** — added an `[Unreleased]` section summarizing the above.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 2.1.1 → unreleased (targeting 2.1.2)

**Tests Performed:**
1. `composer test` against the existing locked toolchain — 143 passed, 1 deprecation (pre-existing).
2. `composer update --dry-run -W` against the L13 path (`laravel/framework:^13.0`, `orchestra/testbench:^11.0`, `pestphp/pest-plugin-laravel:^4.0`) — resolves cleanly.
3. `composer update --dry-run -W` against the L11 path — resolves modulo upstream security advisories that Composer's `block-insecure` filter handles. The CI matrix runs `composer update` without `--no-audit`, so a blocked advisory in CI would surface as a failed matrix row rather than be silently bypassed.
4. `vendor/bin/pint --dirty` — clean.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** No UI surface area changed. This PR only touches dependency constraints, CI configuration, and documentation.

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** No new application tests are required — the change is constraint-only at runtime. The new CI matrix is the test artifact: it runs the existing 143-test suite against each supported Laravel × PHP combination so we catch a future Laravel-13 incompatibility the moment it surfaces.

## Documentation

- [ ] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Requirements sections in `README.md` and `docs/guides/getting-started.md` updated. The Laravel Integration section in the getting-started guide had its Laravel 5.x manual-registration text removed and namespace references corrected.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed (N/A — no UI surface area)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 13 (requires PHP 8.3+; Laravel 11/12 remain compatible with PHP 8.2+)

* **Documentation**
  * Updated README and getting-started guide for supported versions and modern Laravel auto-discovery; removed outdated manual registration instructions

* **Chores**
  * Expanded CI to run tests across Laravel 11–13 with matching PHP versions and improved matrix-aware dependency installation
  * Broadened dependency constraints and moved a previously suggested package into required dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->