### PR TITLE
chore: split release into dedicated workflow with Packagist publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
 
@@ -169,42 +167,3 @@ jobs:
       - name: Run benchmarks
         if: steps.check-phpbench.outputs.exists == 'true'
         run: ./vendor/bin/phpbench run --report=default
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    name: Create Release
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract release notes from CHANGELOG
-        id: changelog
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Extracting notes for version $VERSION"
-
-          if [ -f "CHANGELOG.md" ]; then
-            # Extract section for this version
-            NOTES=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-            if [ -z "$NOTES" ]; then
-              NOTES="Release $VERSION. See CHANGELOG.md for details."
-            fi
-          else
-            NOTES="Release $VERSION"
-          fi
-
-          # Save to file for multi-line support
-          echo "$NOTES" > release_notes.txt
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release_notes.txt
-          generate_release_notes: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Test before release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        env:
+          XDEBUG_MODE: off
+        run: vendor/bin/pest --no-coverage
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Create Release
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          echo "Extracting notes for version $VERSION"
+
+          if [ ! -f "CHANGELOG.md" ]; then
+            echo "Release v$VERSION" > release_notes.txt
+            exit 0
+          fi
+
+          # Extract the section between this version header and the next version header
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Remove leading/trailing blank lines
+          NOTES=$(echo "$NOTES" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')
+
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION — see CHANGELOG.md for details."
+          fi
+
+          # Write to file for multi-line support
+          echo "$NOTES" > release_notes.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.version }}
+          body_path: release_notes.txt
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Packagist
+        if: success()
+        run: |
+          curl --fail-with-body -sS -X POST \
+            "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
+            -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -53,6 +55,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version


### PR DESCRIPTION
## Description

Mirrors the release pipeline used by `artisanpack-ui/cms-framework`: replaces the inline `release` job inside `ci.yml` with a dedicated `release.yml` workflow that triggers on `v*` tag pushes, creates the GitHub release with notes pulled from `CHANGELOG.md`, and pings the Packagist API so the new tag publishes to packagist.org without manual intervention.

**Closes:** N/A (maintenance follow-up to #29; aligns release tooling with cms-framework before cutting v2.1.2)

## Type of Change

- [x] Refactoring (code improvement, no behavior change)

## Motivation and Context

Up to now releases from this repo only created a GitHub Release — Packagist had to be poked manually (or wait for its periodic crawler) before downstream consumers could see the new version. cms-framework already solved this with a dedicated `release.yml` that calls Packagist's `update-package` webhook on success. The user requested the same pattern here so v2.1.2 (the first release on this branch) can ship in a single tag push.

## Changes Made

- **`.github/workflows/release.yml`** — new workflow modeled on the cms-framework equivalent:
  - Triggered on `push.tags: ['v*']` only.
  - `test` job runs the full Pest suite on PHP 8.4 against the locked dependency set as a pre-release sanity check.
  - `release` job extracts the version section from `CHANGELOG.md` via the awk-based extractor cms-framework uses (more robust than the previous sed extractor: it handles multi-line content cleanly and stops on the next `## [` header).
  - Falls back to "`Release v{version} — see CHANGELOG.md for details.`" if the section is empty or missing.
  - Creates the GitHub Release via `softprops/action-gh-release@v2` with an explicit `name: v{version}`.
  - POSTs to `https://packagist.org/api/update-package?username=...&apiToken=...` with the repo URL on success.
- **`.github/workflows/ci.yml`** — drops the now-redundant pieces:
  - Removed the `release` job in its entirety.
  - Removed `tags: ['v*']` from the workflow trigger (release.yml owns tag pushes; ci.yml stays on `push: main` + `pull_request: main`).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 2.1.1 → 2.1.2 (this release branch)

**Tests Performed:**
1. `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml')"` — parses cleanly.
2. `ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml')"` — parses cleanly.
3. CHANGELOG extractor awk block exercised against the existing `## [2.1.1]` section locally; produces the expected release-notes block.
4. End-to-end release will be verified on the first v2.1.2 tag push — see the prerequisite below.

## Prerequisite Before First Release

Two repository secrets must be added before pushing a `v*` tag, otherwise the **Update Packagist** step will fail:

- `PACKAGIST_USERNAME` — the Packagist account that owns this package.
- `PACKAGIST_API_TOKEN` — that account's API token (Packagist → Profile → "Show API token").

cms-framework already uses these same secret names, so the values can be reused. The GitHub Release will still publish even if the Packagist step fails (the curl is the last step in the job), so a missing secret would surface as a job failure on `release` but the tag/release artifact would still exist.

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** No application-code change; nothing new to unit-test. CI itself is the test artifact for the workflow change — the first tag push will exercise it end to end.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** No UI surface area changed.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Workflow files are self-documenting via step names; no user-facing docs touch the release pipeline.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted (YAML validated)
- [x] Accessibility tests completed (N/A — no UI surface area)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Separated release automation into a dedicated, tag-triggered workflow for versioned releases.
  * Removed automated release creation from the main CI pipeline; main branch pushes are no longer tag-gated.
  * Releases are now created only on explicit version tag pushes and include automated release notes generation and package registry updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->