### PR TITLE
feat: add contrast threshold, color map, generated text color hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-21
+
+This release joins the cross-package hooks standardization initiative. `artisanpack-ui/hooks` (`^1.3`) is now a hard dependency, and the color-contrast pipeline fires three filter hooks that let applications override the WCAG threshold, extend the Tailwind color map, and take a final say on the generated text color.
+
+### Added
+- New filter hook `ap.accessibility.contrastThreshold` — `(float $ratio, string $context)`. Fires inside `WcagValidator::checkContrast()` right before the ratio comparison, with the default WCAG threshold and a context string (`aa`, `aa-large`, `aaa`, `aaa-large`, `non-text`). Return a different float to bump every check globally (e.g. force AAA) without touching call sites.
+- New filter hook `ap.accessibility.contrastColorMap` — `(array $map)`. Fires the first time `AccessibleColorGenerator` loads its Tailwind name → hex map, allowing apps to register custom palette entries or replace the map entirely.
+- New filter hook `ap.accessibility.textColorGenerated` — `(string $color, string $bg, bool $tinted)`. Fires at every return path of `AccessibleColorGenerator::generateAccessibleTextColor()` (including cached results), giving apps an escape hatch to override the algorithm for specific backgrounds.
+
+### Changed
+- Added `artisanpack-ui/hooks: ^1.3` as a required dependency.
+
 ## [2.2.0] - 2026-07-08
 
 This release introduces AI-powered accessibility tooling on top of `artisanpack-ui/ai` v1.0. The three new agents — content-level issue analysis, ARIA attribute suggestion, and plain-language contrast-failure explanation — are delivered with framework surfaces for Livewire, React, and Vue that ship inside this package, so extending framework support does not require any changes to `@artisanpack-ui/react` or `@artisanpack-ui/vue`.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,37 @@ Now you can easily create accessible buttons with any background color.
 
 For more detailed examples, including Livewire components and dynamic theming, see the [Real-World Examples](docs/examples.md) documentation.
 
+## Hooks
+
+This package ships with three filter hooks (via `artisanpack-ui/hooks`) that let applications customize the color-contrast pipeline without patching the package:
+
+| Hook                                     | Type   | Payload                                                | Purpose                                                                                                    |
+|------------------------------------------|--------|--------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `ap.accessibility.contrastThreshold`     | filter | `(float $ratio, string $context)`                      | Override the default WCAG threshold. Context is one of `aa`, `aa-large`, `aaa`, `aaa-large`, `non-text`.   |
+| `ap.accessibility.contrastColorMap`      | filter | `(array $map)`                                         | Register custom Tailwind-name → hex mappings or replace the map entirely.                                  |
+| `ap.accessibility.textColorGenerated`    | filter | `(string $color, string $background, bool $tinted)`    | Take a final say on the generated text color. Useful for per-background overrides.                         |
+
+```php
+// Force AAA thresholds everywhere.
+addFilter('ap.accessibility.contrastThreshold', fn (float $ratio, string $context) => match ($context) {
+    'aa', 'aaa'             => 7.0,
+    'aa-large', 'aaa-large' => 4.5,
+    default                 => $ratio,
+});
+
+// Add brand colors that the Tailwind palette does not cover.
+addFilter('ap.accessibility.contrastColorMap', function (array $map) {
+    $map['brand-primary'] = '#123456';
+
+    return $map;
+});
+
+// Force a specific text color for a specific background.
+addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) {
+    return $background === '#123456' ? '#fefefe' : $color;
+});
+```
+
 ## AI features
 
 When `artisanpack-ui/ai` v1.0+ is installed alongside this package, three AI-powered accessibility agents become available. Each is toggle-able through the shared `FeatureRegistry` and no-ops when the toggle is off.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A package for all accessibility functions for ArtisanPack UI.",
   "type": "library",
   "license": "MIT",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "autoload": {
     "psr-4": {
       "ArtisanPack\\Accessibility\\": "src/",
@@ -41,6 +41,7 @@
     "php": "^8.3",
     "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.3",
     "illuminate/support": "^12.0|^13.0"
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95db557c2b2211d7d33a1912ca19e800",
+    "content-hash": "a6244f51299fc7018468452d1e45425d",
     "packages": [
         {
             "name": "artisanpack-ui/ai",
@@ -146,6 +146,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "aws/aws-crt-php",

--- a/src/Core/AccessibleColorGenerator.php
+++ b/src/Core/AccessibleColorGenerator.php
@@ -71,7 +71,7 @@ class AccessibleColorGenerator
         $hexColor = $this->getHexFromColorString($backgroundColor);
 
         if (! $hexColor) {
-            return '#000000';
+            return Hooks::filter('ap.accessibility.textColorGenerated', '#000000', $backgroundColor, $tint);
         }
 
         $cacheKey = $this->getCacheKey($hexColor, $tint, $level, $isLargeText);
@@ -80,7 +80,7 @@ class AccessibleColorGenerator
                 $this->dispatcher->dispatch(new CacheHit($cacheKey));
             }
 
-            return $this->cache->get($cacheKey);
+            return Hooks::filter('ap.accessibility.textColorGenerated', $this->cache->get($cacheKey), $hexColor, $tint);
         }
 
         if ($this->dispatcher) {
@@ -91,7 +91,7 @@ class AccessibleColorGenerator
             $result = $this->findClosestAccessibleShade($hexColor, $level, $isLargeText);
             $this->cache->set($cacheKey, $result);
 
-            return $result;
+            return Hooks::filter('ap.accessibility.textColorGenerated', $result, $hexColor, $tint);
         }
 
         $blackContrast = $this->wcagValidator->calculateContrastRatio($hexColor, '#000000');
@@ -100,7 +100,7 @@ class AccessibleColorGenerator
         $result = $blackContrast > $whiteContrast ? '#000000' : '#FFFFFF';
         $this->cache->set($cacheKey, $result);
 
-        return $result;
+        return Hooks::filter('ap.accessibility.textColorGenerated', $result, $hexColor, $tint);
     }
 
     public function getCacheKey(string $hexColor, bool $tint, string $level, bool $isLargeText): string
@@ -165,7 +165,9 @@ class AccessibleColorGenerator
 
         // Check if it's a known Tailwind color.
         if ($this->tailwindColors === null) {
-            $this->tailwindColors = require __DIR__.'/../../resources/tailwind-colors.php';
+            $map = require __DIR__.'/../../resources/tailwind-colors.php';
+            $filtered = Hooks::filter('ap.accessibility.contrastColorMap', $map);
+            $this->tailwindColors = is_array($filtered) ? $filtered : $map;
         }
 
         return $this->tailwindColors[$colorString] ?? null;

--- a/src/Core/Hooks.php
+++ b/src/Core/Hooks.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ArtisanPack\Accessibility\Core;
+
+use Throwable;
+
+/**
+ * Internal helper for firing `artisanpack-ui/hooks` filters from the
+ * accessibility package without breaking framework-agnostic usage.
+ *
+ * The Facade dispatched by `applyFilters()` throws when no Laravel
+ * application container is bound (e.g. when the package is used outside
+ * of a Laravel app). This helper swallows that specific failure and
+ * returns the caller's default, so contrast checks and color decisions
+ * keep working in framework-agnostic mode.
+ */
+class Hooks
+{
+    public static function filter(string $hook, mixed $default, mixed ...$args): mixed
+    {
+        try {
+            return applyFilters($hook, $default, ...$args);
+        } catch (Throwable) {
+            return $default;
+        }
+    }
+}

--- a/src/Core/WcagValidator.php
+++ b/src/Core/WcagValidator.php
@@ -55,25 +55,24 @@ class WcagValidator
         $this->_validateHexColor($color2);
 
         $ratio = $this->calculateContrastRatio($color1, $color2);
+        $normalizedLevel = strtolower($level);
 
-        if ($isLargeText) {
-            return match (strtoupper($level)) {
-                'AA' => $ratio >= 3,
-                'AAA' => $ratio >= 4.5,
-                'NON-TEXT' => $ratio >= 3,
-                default => false,
-            };
-        }
-
-        $result = match (strtoupper($level)) {
-            'AA' => $ratio >= 4.5,
-            'AAA' => $ratio >= 7,
-            'NON-TEXT' => $ratio >= 3,
-            default => false,
+        $defaultThreshold = match ($normalizedLevel) {
+            'aa' => $isLargeText ? 3.0 : 4.5,
+            'aaa' => $isLargeText ? 4.5 : 7.0,
+            'non-text' => 3.0,
+            default => INF,
         };
 
-        // Only dispatch the event if the Laravel event helper is available
-        if (function_exists('event')) {
+        $context = ($isLargeText && $normalizedLevel !== 'non-text')
+            ? "{$normalizedLevel}-large"
+            : $normalizedLevel;
+
+        $threshold = (float) Hooks::filter('ap.accessibility.contrastThreshold', $defaultThreshold, $context);
+
+        $result = $ratio >= $threshold;
+
+        if (! $isLargeText && function_exists('event')) {
             try {
                 event(new \ArtisanPack\Accessibility\Events\ColorContrastChecked($color1, $color2, $level, $isLargeText, $result));
             } catch (\Throwable $e) {

--- a/tests/Feature/HooksTest.php
+++ b/tests/Feature/HooksTest.php
@@ -1,0 +1,100 @@
+<?php
+
+uses(Tests\TestCase::class);
+
+use ArtisanPack\Accessibility\Core\AccessibleColorGenerator;
+use ArtisanPack\Accessibility\Core\WcagValidator;
+use ArtisanPackUI\Hooks\Facades\Filter;
+
+beforeEach(function () {
+    Filter::removeAll('ap.accessibility.contrastThreshold');
+    Filter::removeAll('ap.accessibility.contrastColorMap');
+    Filter::removeAll('ap.accessibility.textColorGenerated');
+});
+
+it('ap.accessibility.contrastThreshold filter overrides the default WCAG AA threshold', function () {
+    $validator = new WcagValidator;
+
+    // #767676 on white has ratio ~4.54:1 → passes default AA (4.5).
+    expect($validator->checkContrast('#767676', '#FFFFFF', 'AA'))->toBeTrue();
+
+    $received = [];
+    addFilter('ap.accessibility.contrastThreshold', function (float $ratio, string $context) use (&$received) {
+        $received[] = [$ratio, $context];
+
+        // Force AAA-level (7.0) threshold globally, regardless of caller.
+        return 7.0;
+    });
+
+    expect($validator->checkContrast('#767676', '#FFFFFF', 'AA'))->toBeFalse();
+    expect($received)->not->toBeEmpty();
+    expect($received[0][0])->toBe(4.5);
+    expect($received[0][1])->toBe('aa');
+});
+
+it('ap.accessibility.contrastThreshold filter receives large-text context', function () {
+    $validator = new WcagValidator;
+    $captured = null;
+
+    addFilter('ap.accessibility.contrastThreshold', function (float $ratio, string $context) use (&$captured) {
+        $captured = $context;
+
+        return $ratio;
+    });
+
+    $validator->checkContrast('#FFFFFF', '#000000', 'AA', true);
+
+    expect($captured)->toBe('aa-large');
+});
+
+it('ap.accessibility.contrastColorMap filter can register custom palette entries', function () {
+    $generator = new AccessibleColorGenerator;
+
+    // Unknown color name returns null before filtering.
+    expect($generator->getHexFromColorString('brand-primary'))->toBeNull();
+
+    addFilter('ap.accessibility.contrastColorMap', function (array $map) {
+        $map['brand-primary'] = '#123456';
+
+        return $map;
+    });
+
+    // Fresh generator so the cached map is loaded through the filter.
+    $freshGenerator = new AccessibleColorGenerator;
+    expect($freshGenerator->getHexFromColorString('brand-primary'))->toBe('#123456');
+});
+
+it('ap.accessibility.textColorGenerated filter can override the final decision', function () {
+    $generator = new AccessibleColorGenerator;
+
+    expect($generator->generateAccessibleTextColor('#FFFFFF'))->toBe('#000000');
+
+    $captured = [];
+    addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) use (&$captured) {
+        $captured[] = [$color, $background, $tinted];
+
+        return '#ff00ff';
+    });
+
+    // Fresh generator so the cached bw.* entry does not hide the newly-run pipeline.
+    $freshGenerator = new AccessibleColorGenerator;
+    expect($freshGenerator->generateAccessibleTextColor('#FFFFFF'))->toBe('#ff00ff');
+    expect($captured)->toHaveCount(1);
+    expect($captured[0][0])->toBe('#000000');
+    expect($captured[0][1])->toBe('#ffffff');
+    expect($captured[0][2])->toBeFalse();
+});
+
+it('ap.accessibility.textColorGenerated filter also runs for tinted output', function () {
+    $captured = null;
+    addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) use (&$captured) {
+        $captured = $tinted;
+
+        return $color;
+    });
+
+    $generator = new AccessibleColorGenerator;
+    $generator->generateAccessibleTextColor('#3b82f6', true);
+
+    expect($captured)->toBeTrue();
+});


### PR DESCRIPTION
## Description

Wave 5 hooks adoption for the accessibility package. Adds `artisanpack-ui/hooks: ^1.3` as a required dependency and fires three filter hooks from the color-contrast pipeline.

**Closes:** #38

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #38

## Motivation and Context

Before this PR, the accessibility package fired zero hooks. Apps needing to bump the WCAG threshold globally, register custom palette colors, or override the generated text-color decision had to fork the package or patch call sites. Wave 5 of the cross-package hooks standardization initiative gives them the three escape hatches the issue calls out.

## Changes Made

- Added `artisanpack-ui/hooks: ^1.3` as a required dependency; bumped package version to `2.3.0`.
- `WcagValidator::checkContrast()` now fires `ap.accessibility.contrastThreshold` filter — `(float $ratio, string $context)` where context is `aa`, `aa-large`, `aaa`, `aaa-large`, or `non-text`.
- `AccessibleColorGenerator::getHexFromColorString()` fires `ap.accessibility.contrastColorMap` filter when it first loads the Tailwind name → hex map.
- `AccessibleColorGenerator::generateAccessibleTextColor()` fires `ap.accessibility.textColorGenerated` filter on every return path (invalid hex, cache hit, tinted, black/white).
- New internal `Core\Hooks::filter()` helper centralizes the try/catch that keeps framework-agnostic usage working when the Hooks Facade has no app container bound.
- Documented the new hooks in `README.md` and `CHANGELOG.md`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.5
- Project Version: 2.3.0

**Tests Performed:**
1. Ran full Pest suite — 48 tests, 357 assertions, all passing.
2. Ran Pint on the modified files — clean.
3. Verified `FrameworkAgnosticTest` still passes, confirming the `Hooks::filter()` fallback preserves no-Laravel usage.

## Accessibility Tests Run

- [x] Color contrast verified (existing `WcagValidatorTest` + `AccessibleColorGeneratorTest` still green; the diff does not change default behavior when no filters are registered)

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/HooksTest.php` — one test per hook, plus a large-text-context test and a tinted-payload test (5 tests total).

## Documentation

- [x] README updated
- [x] Inline code documentation added

**Documentation details:** New "Hooks" section in `README.md` with a hook table and copy-pasteable examples for each filter. `CHANGELOG.md` gets a `2.3.0` entry.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated