### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-21
+
+This release joins the cross-package hooks standardization initiative. `artisanpack-ui/hooks` (`^1.3`) is now a hard dependency, and the color-contrast pipeline fires three filter hooks that let applications override the WCAG threshold, extend the Tailwind color map, and take a final say on the generated text color.
+
+### Added
+- New filter hook `ap.accessibility.contrastThreshold` — `(float $ratio, string $context)`. Fires inside `WcagValidator::checkContrast()` right before the ratio comparison, with the default WCAG threshold and a context string (`aa`, `aa-large`, `aaa`, `aaa-large`, `non-text`). Return a different float to bump every check globally (e.g. force AAA) without touching call sites.
+- New filter hook `ap.accessibility.contrastColorMap` — `(array $map)`. Fires the first time `AccessibleColorGenerator` loads its Tailwind name → hex map, allowing apps to register custom palette entries or replace the map entirely.
+- New filter hook `ap.accessibility.textColorGenerated` — `(string $color, string $bg, bool $tinted)`. Fires at every return path of `AccessibleColorGenerator::generateAccessibleTextColor()` (including cached results), giving apps an escape hatch to override the algorithm for specific backgrounds.
+
+### Changed
+- Added `artisanpack-ui/hooks: ^1.3` as a required dependency.
+
 ## [2.2.0] - 2026-07-08
 
 This release introduces AI-powered accessibility tooling on top of `artisanpack-ui/ai` v1.0. The three new agents — content-level issue analysis, ARIA attribute suggestion, and plain-language contrast-failure explanation — are delivered with framework surfaces for Livewire, React, and Vue that ship inside this package, so extending framework support does not require any changes to `@artisanpack-ui/react` or `@artisanpack-ui/vue`.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,37 @@ Now you can easily create accessible buttons with any background color.
 
 For more detailed examples, including Livewire components and dynamic theming, see the [Real-World Examples](docs/examples.md) documentation.
 
+## Hooks
+
+This package ships with three filter hooks (via `artisanpack-ui/hooks`) that let applications customize the color-contrast pipeline without patching the package:
+
+| Hook                                     | Type   | Payload                                                | Purpose                                                                                                    |
+|------------------------------------------|--------|--------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `ap.accessibility.contrastThreshold`     | filter | `(float $ratio, string $context)`                      | Override the default WCAG threshold. Context is one of `aa`, `aa-large`, `aaa`, `aaa-large`, `non-text`.   |
+| `ap.accessibility.contrastColorMap`      | filter | `(array $map)`                                         | Register custom Tailwind-name → hex mappings or replace the map entirely.                                  |
+| `ap.accessibility.textColorGenerated`    | filter | `(string $color, string $background, bool $tinted)`    | Take a final say on the generated text color. Useful for per-background overrides.                         |
+
+```php
+// Force AAA thresholds everywhere.
+addFilter('ap.accessibility.contrastThreshold', fn (float $ratio, string $context) => match ($context) {
+    'aa', 'aaa'             => 7.0,
+    'aa-large', 'aaa-large' => 4.5,
+    default                 => $ratio,
+});
+
+// Add brand colors that the Tailwind palette does not cover.
+addFilter('ap.accessibility.contrastColorMap', function (array $map) {
+    $map['brand-primary'] = '#123456';
+
+    return $map;
+});
+
+// Force a specific text color for a specific background.
+addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) {
+    return $background === '#123456' ? '#fefefe' : $color;
+});
+```
+
 ## AI features
 
 When `artisanpack-ui/ai` v1.0+ is installed alongside this package, three AI-powered accessibility agents become available. Each is toggle-able through the shared `FeatureRegistry` and no-ops when the toggle is off.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A package for all accessibility functions for ArtisanPack UI.",
   "type": "library",
   "license": "MIT",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "autoload": {
     "psr-4": {
       "ArtisanPack\\Accessibility\\": "src/",
@@ -41,6 +41,7 @@
     "php": "^8.3",
     "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.3",
     "illuminate/support": "^12.0|^13.0"
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6244f51299fc7018468452d1e45425d",
+    "content-hash": "317fd414142eeb8b2c28405214a280f7",
     "packages": [
         {
             "name": "artisanpack-ui/ai",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95db557c2b2211d7d33a1912ca19e800",
+    "content-hash": "a6244f51299fc7018468452d1e45425d",
     "packages": [
         {
             "name": "artisanpack-ui/ai",
@@ -146,6 +146,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "aws/aws-crt-php",

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -23,6 +23,12 @@ Detailed examples and practical implementations of the package's features. This 
 - Practical examples for real-world scenarios
 - Advanced usage patterns
 
+### [Hooks](Guides-Hooks)
+Filter hooks (introduced in 2.3.0) that let applications customize the color-contrast pipeline without patching the package:
+- `ap.accessibility.contrastThreshold` — override the WCAG threshold globally
+- `ap.accessibility.contrastColorMap` — extend or replace the Tailwind color map
+- `ap.accessibility.textColorGenerated` — final say on generated text colors
+
 ### [AI Features](Guides-Ai-Features)
 AI-powered accessibility tooling introduced in 2.2.0, built on top of `artisanpack-ui/ai` v1.0:
 - Content-level accessibility analysis (`ContentAccessibilityAgent`)

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -1,0 +1,72 @@
+---
+title: Hooks
+---
+
+# Hooks (2.3.0+)
+
+Starting in 2.3.0, this package ships three filter hooks (via `artisanpack-ui/hooks`) that let applications customize the color-contrast pipeline without patching the package. Hooks are registered with `addFilter()` and fired via `Hooks::filter()` from inside the package.
+
+## Available Hooks
+
+| Hook | Type | Payload | Purpose |
+|------|------|---------|---------|
+| `ap.accessibility.contrastThreshold` | filter | `(float $ratio, string $context)` | Override the default WCAG threshold. Context is one of `aa`, `aa-large`, `aaa`, `aaa-large`, `non-text`. |
+| `ap.accessibility.contrastColorMap` | filter | `(array $map)` | Register custom Tailwind-name → hex mappings or replace the map entirely. |
+| `ap.accessibility.textColorGenerated` | filter | `(string $color, string $background, bool $tinted)` | Take a final say on the generated text color. Fires at every return path (including cached results). |
+
+## `ap.accessibility.contrastThreshold`
+
+Fires inside `WcagValidator::checkContrast()` right before the ratio comparison. Return a different float to bump every check globally — useful when an application wants to force AAA thresholds everywhere without touching call sites.
+
+```php
+addFilter('ap.accessibility.contrastThreshold', fn (float $ratio, string $context) => match ($context) {
+    'aa', 'aaa'             => 7.0,
+    'aa-large', 'aaa-large' => 4.5,
+    default                 => $ratio,
+});
+```
+
+## `ap.accessibility.contrastColorMap`
+
+Fires the first time `AccessibleColorGenerator` loads its Tailwind name → hex map. Use it to register brand colors that the default Tailwind palette does not cover, or to replace the map entirely with a custom design-system palette.
+
+```php
+addFilter('ap.accessibility.contrastColorMap', function (array $map) {
+    $map['brand-primary'] = '#123456';
+    $map['brand-accent']  = '#abcdef';
+
+    return $map;
+});
+```
+
+## `ap.accessibility.textColorGenerated`
+
+Fires at every return path of `AccessibleColorGenerator::generateAccessibleTextColor()`, including cached results. This is the escape hatch for per-background overrides when the algorithm's answer isn't what you want.
+
+```php
+addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) {
+    return $background === '#123456' ? '#fefefe' : $color;
+});
+```
+
+## Where to Register
+
+Register hooks in a service provider's `boot()` method so they are in place before any accessibility calls are made:
+
+```php
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AccessibilityHooksServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        addFilter('ap.accessibility.contrastThreshold', /* ... */);
+        addFilter('ap.accessibility.contrastColorMap', /* ... */);
+        addFilter('ap.accessibility.textColorGenerated', /* ... */);
+    }
+}
+```
+
+See the [artisanpack-ui/hooks documentation](https://github.com/ArtisanPack-UI/hooks) for the full hook API, including priorities and removal.

--- a/docs/home.md
+++ b/docs/home.md
@@ -13,6 +13,7 @@ Complete guides to help you get started and effectively use the package:
 - [Getting Started](Guides-Getting-Started): Installation and basic setup instructions
 - [Usage Guide](Guides-Usage): Detailed examples of how to use the package's features
 - [Artisan Commands](Commands): Using CLI to audit colors and generate palettes
+- [Hooks](Guides-Hooks): Filter hooks for customizing the color-contrast pipeline (2.3.0+)
 - [AI Features](Guides-Ai-Features): AI-powered content analysis, ARIA suggestion, and contrast explanation (2.2.0+)
 
 ### [Reference](Reference)

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -197,6 +197,46 @@ Determines the best-contrasting text color. It can return either black or white,
 $textColor = generateAccessibleTextColor('#3b82f6'); // Returns '#000000' or '#FFFFFF'
 $tintedColor = generateAccessibleTextColor('#3b82f6', true); // Returns a tinted/shaded hex color
 ```
+## Filter Hooks (2.3.0+)
+
+Three filter hooks (fired via `artisanpack-ui/hooks`) let applications customize the color-contrast pipeline. See the [Hooks guide](Guides-Hooks) for narrative walkthroughs and registration examples.
+
+### `ap.accessibility.contrastThreshold`
+
+Fires inside `WcagValidator::checkContrast()` immediately before the ratio comparison.
+
+**Signature:** `(float $ratio, string $context): float`
+
+**Parameters:**
+- `$ratio` (float): The default WCAG threshold for the given context.
+- `$context` (string): One of `aa`, `aa-large`, `aaa`, `aaa-large`, `non-text`.
+
+**Returns:** The threshold (as a float) that `checkContrast()` should use.
+
+### `ap.accessibility.contrastColorMap`
+
+Fires the first time `AccessibleColorGenerator` loads its Tailwind name → hex map.
+
+**Signature:** `(array $map): array`
+
+**Parameters:**
+- `$map` (array<string, string>): The Tailwind color name → hex mapping.
+
+**Returns:** The map to use. Add entries to extend the palette or return a completely different map to replace it.
+
+### `ap.accessibility.textColorGenerated`
+
+Fires at every return path of `AccessibleColorGenerator::generateAccessibleTextColor()`, including cached results.
+
+**Signature:** `(string $color, string $background, bool $tinted): string`
+
+**Parameters:**
+- `$color` (string): The generated hex text color.
+- `$background` (string): The hex background color that was passed in.
+- `$tinted` (bool): Whether the tinted variant was requested.
+
+**Returns:** The final hex text color.
+
 ## AI Agents (2.2.0+)
 
 Three AI-powered agents built on top of `artisanpack-ui/ai` v1.0. See the [AI Features guide](Guides-Ai-Features) for prose walkthroughs, framework surfaces, and Sanctum setup.

--- a/src/Core/AccessibleColorGenerator.php
+++ b/src/Core/AccessibleColorGenerator.php
@@ -71,7 +71,7 @@ class AccessibleColorGenerator
         $hexColor = $this->getHexFromColorString($backgroundColor);
 
         if (! $hexColor) {
-            return '#000000';
+            return Hooks::filter('ap.accessibility.textColorGenerated', '#000000', $backgroundColor, $tint);
         }
 
         $cacheKey = $this->getCacheKey($hexColor, $tint, $level, $isLargeText);
@@ -80,7 +80,7 @@ class AccessibleColorGenerator
                 $this->dispatcher->dispatch(new CacheHit($cacheKey));
             }
 
-            return $this->cache->get($cacheKey);
+            return Hooks::filter('ap.accessibility.textColorGenerated', $this->cache->get($cacheKey), $hexColor, $tint);
         }
 
         if ($this->dispatcher) {
@@ -91,7 +91,7 @@ class AccessibleColorGenerator
             $result = $this->findClosestAccessibleShade($hexColor, $level, $isLargeText);
             $this->cache->set($cacheKey, $result);
 
-            return $result;
+            return Hooks::filter('ap.accessibility.textColorGenerated', $result, $hexColor, $tint);
         }
 
         $blackContrast = $this->wcagValidator->calculateContrastRatio($hexColor, '#000000');
@@ -100,7 +100,7 @@ class AccessibleColorGenerator
         $result = $blackContrast > $whiteContrast ? '#000000' : '#FFFFFF';
         $this->cache->set($cacheKey, $result);
 
-        return $result;
+        return Hooks::filter('ap.accessibility.textColorGenerated', $result, $hexColor, $tint);
     }
 
     public function getCacheKey(string $hexColor, bool $tint, string $level, bool $isLargeText): string
@@ -165,7 +165,9 @@ class AccessibleColorGenerator
 
         // Check if it's a known Tailwind color.
         if ($this->tailwindColors === null) {
-            $this->tailwindColors = require __DIR__.'/../../resources/tailwind-colors.php';
+            $map = require __DIR__.'/../../resources/tailwind-colors.php';
+            $filtered = Hooks::filter('ap.accessibility.contrastColorMap', $map);
+            $this->tailwindColors = is_array($filtered) ? $filtered : $map;
         }
 
         return $this->tailwindColors[$colorString] ?? null;

--- a/src/Core/Hooks.php
+++ b/src/Core/Hooks.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ArtisanPack\Accessibility\Core;
+
+use Throwable;
+
+/**
+ * Internal helper for firing `artisanpack-ui/hooks` filters from the
+ * accessibility package without breaking framework-agnostic usage.
+ *
+ * The Facade dispatched by `applyFilters()` throws when no Laravel
+ * application container is bound (e.g. when the package is used outside
+ * of a Laravel app). This helper swallows that specific failure and
+ * returns the caller's default, so contrast checks and color decisions
+ * keep working in framework-agnostic mode.
+ */
+class Hooks
+{
+    public static function filter(string $hook, mixed $default, mixed ...$args): mixed
+    {
+        try {
+            return applyFilters($hook, $default, ...$args);
+        } catch (Throwable) {
+            return $default;
+        }
+    }
+}

--- a/src/Core/WcagValidator.php
+++ b/src/Core/WcagValidator.php
@@ -55,25 +55,24 @@ class WcagValidator
         $this->_validateHexColor($color2);
 
         $ratio = $this->calculateContrastRatio($color1, $color2);
+        $normalizedLevel = strtolower($level);
 
-        if ($isLargeText) {
-            return match (strtoupper($level)) {
-                'AA' => $ratio >= 3,
-                'AAA' => $ratio >= 4.5,
-                'NON-TEXT' => $ratio >= 3,
-                default => false,
-            };
-        }
-
-        $result = match (strtoupper($level)) {
-            'AA' => $ratio >= 4.5,
-            'AAA' => $ratio >= 7,
-            'NON-TEXT' => $ratio >= 3,
-            default => false,
+        $defaultThreshold = match ($normalizedLevel) {
+            'aa' => $isLargeText ? 3.0 : 4.5,
+            'aaa' => $isLargeText ? 4.5 : 7.0,
+            'non-text' => 3.0,
+            default => INF,
         };
 
-        // Only dispatch the event if the Laravel event helper is available
-        if (function_exists('event')) {
+        $context = ($isLargeText && $normalizedLevel !== 'non-text')
+            ? "{$normalizedLevel}-large"
+            : $normalizedLevel;
+
+        $threshold = (float) Hooks::filter('ap.accessibility.contrastThreshold', $defaultThreshold, $context);
+
+        $result = $ratio >= $threshold;
+
+        if (! $isLargeText && function_exists('event')) {
             try {
                 event(new \ArtisanPack\Accessibility\Events\ColorContrastChecked($color1, $color2, $level, $isLargeText, $result));
             } catch (\Throwable $e) {

--- a/tests/Feature/HooksTest.php
+++ b/tests/Feature/HooksTest.php
@@ -1,0 +1,100 @@
+<?php
+
+uses(Tests\TestCase::class);
+
+use ArtisanPack\Accessibility\Core\AccessibleColorGenerator;
+use ArtisanPack\Accessibility\Core\WcagValidator;
+use ArtisanPackUI\Hooks\Facades\Filter;
+
+beforeEach(function () {
+    Filter::removeAll('ap.accessibility.contrastThreshold');
+    Filter::removeAll('ap.accessibility.contrastColorMap');
+    Filter::removeAll('ap.accessibility.textColorGenerated');
+});
+
+it('ap.accessibility.contrastThreshold filter overrides the default WCAG AA threshold', function () {
+    $validator = new WcagValidator;
+
+    // #767676 on white has ratio ~4.54:1 → passes default AA (4.5).
+    expect($validator->checkContrast('#767676', '#FFFFFF', 'AA'))->toBeTrue();
+
+    $received = [];
+    addFilter('ap.accessibility.contrastThreshold', function (float $ratio, string $context) use (&$received) {
+        $received[] = [$ratio, $context];
+
+        // Force AAA-level (7.0) threshold globally, regardless of caller.
+        return 7.0;
+    });
+
+    expect($validator->checkContrast('#767676', '#FFFFFF', 'AA'))->toBeFalse();
+    expect($received)->not->toBeEmpty();
+    expect($received[0][0])->toBe(4.5);
+    expect($received[0][1])->toBe('aa');
+});
+
+it('ap.accessibility.contrastThreshold filter receives large-text context', function () {
+    $validator = new WcagValidator;
+    $captured = null;
+
+    addFilter('ap.accessibility.contrastThreshold', function (float $ratio, string $context) use (&$captured) {
+        $captured = $context;
+
+        return $ratio;
+    });
+
+    $validator->checkContrast('#FFFFFF', '#000000', 'AA', true);
+
+    expect($captured)->toBe('aa-large');
+});
+
+it('ap.accessibility.contrastColorMap filter can register custom palette entries', function () {
+    $generator = new AccessibleColorGenerator;
+
+    // Unknown color name returns null before filtering.
+    expect($generator->getHexFromColorString('brand-primary'))->toBeNull();
+
+    addFilter('ap.accessibility.contrastColorMap', function (array $map) {
+        $map['brand-primary'] = '#123456';
+
+        return $map;
+    });
+
+    // Fresh generator so the cached map is loaded through the filter.
+    $freshGenerator = new AccessibleColorGenerator;
+    expect($freshGenerator->getHexFromColorString('brand-primary'))->toBe('#123456');
+});
+
+it('ap.accessibility.textColorGenerated filter can override the final decision', function () {
+    $generator = new AccessibleColorGenerator;
+
+    expect($generator->generateAccessibleTextColor('#FFFFFF'))->toBe('#000000');
+
+    $captured = [];
+    addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) use (&$captured) {
+        $captured[] = [$color, $background, $tinted];
+
+        return '#ff00ff';
+    });
+
+    // Fresh generator so the cached bw.* entry does not hide the newly-run pipeline.
+    $freshGenerator = new AccessibleColorGenerator;
+    expect($freshGenerator->generateAccessibleTextColor('#FFFFFF'))->toBe('#ff00ff');
+    expect($captured)->toHaveCount(1);
+    expect($captured[0][0])->toBe('#000000');
+    expect($captured[0][1])->toBe('#ffffff');
+    expect($captured[0][2])->toBeFalse();
+});
+
+it('ap.accessibility.textColorGenerated filter also runs for tinted output', function () {
+    $captured = null;
+    addFilter('ap.accessibility.textColorGenerated', function (string $color, string $background, bool $tinted) use (&$captured) {
+        $captured = $tinted;
+
+        return $color;
+    });
+
+    $generator = new AccessibleColorGenerator;
+    $generator->generateAccessibleTextColor('#3b82f6', true);
+
+    expect($captured)->toBeTrue();
+});


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.3.0
- **Release Date:** 2026-07-21
- **Release Type:** Minor
- **Release Branch:** `release/2.3`
- **Target Branch:** `main`

## Release Summary

2.3.0 joins the cross-package hooks standardization initiative. `artisanpack-ui/hooks` (`^1.3`) is now a hard dependency, and the color-contrast pipeline fires three filter hooks that let applications override the WCAG threshold, extend the Tailwind color map, and take a final say on the generated text color — all without patching the package.

## Changelog

### Added
- New filter hook `ap.accessibility.contrastThreshold` — `(float $ratio, string $context)`. Fires inside `WcagValidator::checkContrast()` right before the ratio comparison. Return a different float to bump every check globally (e.g. force AAA).
- New filter hook `ap.accessibility.contrastColorMap` — `(array $map)`. Fires the first time `AccessibleColorGenerator` loads its Tailwind name → hex map, allowing apps to register custom palette entries or replace the map entirely.
- New filter hook `ap.accessibility.textColorGenerated` — `(string $color, string $bg, bool $tinted)`. Fires at every return path of `AccessibleColorGenerator::generateAccessibleTextColor()` (including cached results), giving apps an escape hatch to override the algorithm for specific backgrounds.
- New `docs/guides/hooks.md` guide + "Filter Hooks (2.3.0+)" section in `docs/reference/api-reference.md`.

### Changed
- Added `artisanpack-ui/hooks: ^1.3` as a required dependency.

### Deprecated
- None.

### Removed
- None.

### Fixed
- None.

### Security
- None.

## Issues and Pull Requests

**Related PRs:**
- #39 — feat: add contrast threshold, color map, generated text color hooks

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (48 passed, 357 assertions)
- [ ] Manual testing completed
- [x] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed (see notes)
- [ ] Tested in staging environment
- [ ] Database migrations tested (n/a)

**Testing notes:**
`./vendor/bin/pest --compact` reports 48 passing tests. PHP 8.5 deprecation warnings from PHPUnit metadata in doc-comments and Nunomaduro Collision's use of `ReflectionMethod::setAccessible()` — noise from the toolchain, not failures.

## Documentation Checklist

- [x] CHANGELOG updated (2.3.0 dated 2026-07-21)
- [x] README updated (Hooks section already covers all three hooks)
- [x] API documentation updated (new "Filter Hooks (2.3.0+)" section)
- [ ] Migration guide written (no breaking changes)
- [x] Release notes written (see Release Summary)
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json → 2.3.0)
- [ ] Git tag prepared: `v2.3.0`
- [x] Release branch created/updated: `release/2.3`
- [x] Dependencies updated and tested (composer.lock in sync)
- [ ] Build artifacts generated
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Dependency Audit

- **Lock file:** in sync with composer.json (`composer update --lock` produced no changes)
- **Vulnerabilities:** `composer audit` reports 6 advisories affecting 3 packages — all in the transitive `dev` dependency tree, none affecting runtime.
- **Abandoned:** `doctrine/annotations` (transitive dev dep, no replacement suggested).

## Post-Release Tasks

- [ ] Tag created: `v2.3.0`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

Users staying on PHP 8.2 or Laravel 11 should pin to `^2.1.2` (support was dropped in 2.2.0, unchanged here).

---

**Release Manager:** @jmartella


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable accessibility hooks for WCAG contrast thresholds, color mappings, and generated text colors.
  * Added support for overriding accessible text colors across all generation paths, including cached results.
  * Released version 2.3.0 with the required hooks integration.

* **Documentation**
  * Added guides, API reference details, examples, and navigation for accessibility hooks.

* **Tests**
  * Added coverage for threshold, color map, and generated text color customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->